### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 'build-test'
 on: # rebuild any PRs and main branch changes
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/yahorry/go-swag-action/security/code-scanning/1](https://github.com/yahorry/go-swag-action/security/code-scanning/1)

To fix this issue, add a `permissions` key at the root of the workflow file. This will apply the permissions to all jobs (`build` and `test`) unless overridden by a job-specific `permissions` key. Based on the workflow steps, the minimal permissions required are likely `contents: read`. 

1. Add the `permissions` block with `contents: read` at the root level of the workflow file.
2. Ensure no additional permissions are granted unless explicitly required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
