### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -4,7 +4,6 @@
 # For our project, we generate this file through a build process from other source files.
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist
-
 permissions:
   contents: read
 

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -5,6 +5,9 @@
 # We need to make sure the checked-in `index.js` actually matches what we expect it to be.
 name: Check dist
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
+name: 'build-test'
 permissions:
   contents: read
-name: 'build-test'
+
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yahorry/go-swag-action/security/code-scanning/2](https://github.com/yahorry/go-swag-action/security/code-scanning/2)

To resolve the issue, add a `permissions` block to the workflow to explicitly limit the permissions of the GITHUB_TOKEN. Since the workflow primarily reads repository contents and performs local operations (such as installing dependencies, building files, and comparing directories), the permissions can be restricted to `contents: read`.

The best way to implement the fix is to add the `permissions` key at the root level of the workflow (before the `jobs` section). This will apply the reduced permissions to all jobs in the workflow unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
